### PR TITLE
clang tidy specific timeout

### DIFF
--- a/check_clang_tidy.sh
+++ b/check_clang_tidy.sh
@@ -31,7 +31,7 @@ _travis_run_clang_tidy_fix() {
             fi
         fi
 
-        travis_run_simple --no-assert --timeout $(travis_timeout) "$RUN_CLANG_TIDY_EXECUTABLE" -fix -header-filter='$ROS_WS/src/$REPOSITORY_NAME/.*' -p "${PKGS[$pkg]}" ${modified_files[@]:-} 2> /dev/null
+        travis_run_simple --no-assert --timeout $(travis_timeout 45) "$RUN_CLANG_TIDY_EXECUTABLE" -fix -header-filter='$ROS_WS/src/$REPOSITORY_NAME/.*' -p "${PKGS[$pkg]}" ${modified_files[@]:-} 2> /dev/null
         # if there are workspace changes, print broken pkg to file descriptor 3
         travis_have_fixes && 1>&3 echo $pkg || true  # should always succeed ;-)
         travis_fold end clang.tidy

--- a/util.sh
+++ b/util.sh
@@ -65,7 +65,7 @@ travis_timeout() {
     result=0  # $1 looks like integer that should be consumed as a parameter
   else
     result=1  # parameter shouldn't be consumed
-    timeout=45  # default timeout
+    timeout=20  # default timeout
   fi
 
   # remaining time in minutes (default timeout for open-source Travis jobs is 50min)


### PR DESCRIPTION
This way the function travis_timeout is called with an specific timeout for the clang_tidy call and other function calls are not increased ... at least thats how I understand it.

alternative would be:

<pre>
travis_timeout() {
  # remaining time in minutes (default timeout for open-source Travis jobs is 50min)
  remaining=$(( ${MOVEIT_CI_TRAVIS_TIMEOUT:-50} - ($(travis_nanoseconds) - $MOVEIT_CI_START_TIME) / 60000000000 ))
  
  local timeout result remaining
  if [[ "${timeout:=${1:-}}" =~ ^<b>-?</b>[0-9]+$ ]] ; then
    result=0  # $1 looks like integer that should be consumed as a parameter
  else 
    result=1  # parameter shouldn't be consumed
    timeout=20  # default timeout
  fi

  # limit timeout to remaining time
  if [ $remaining -le $timeout ] <b>|| [ $timeout -l 0 ] </b>; then timeout=$remaining; fi
  
  echo "${timeout}"
  return $result
}
</pre>

and then call it with -1 instead so the whole remaining time would be consumable.